### PR TITLE
Handle missing FHIR library in bundle assembler type hints

### DIFF
--- a/src/nl_fhir/services/fhir/bundle_assembler.py
+++ b/src/nl_fhir/services/fhir/bundle_assembler.py
@@ -5,7 +5,7 @@ HIPAA Compliant: Secure bundle creation and validation
 """
 
 import logging
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, TYPE_CHECKING
 from datetime import datetime, timezone
 from uuid import uuid4
 
@@ -15,6 +15,11 @@ try:
     FHIR_AVAILABLE = True
 except ImportError:
     FHIR_AVAILABLE = False
+
+if TYPE_CHECKING:
+    from fhir.resources.bundle import BundleEntry as BundleEntryType
+else:
+    BundleEntryType = Any
 
 logger = logging.getLogger(__name__)
 
@@ -257,7 +262,7 @@ class FHIRBundleAssembler:
             logger.error(f"[{request_id}] Bundle optimization failed: {e}")
             return bundle
     
-    def _create_bundle_entry(self, resource: Dict[str, Any]) -> Optional[BundleEntry]:
+    def _create_bundle_entry(self, resource: Dict[str, Any]) -> Optional[BundleEntryType]:
         """Create bundle entry with appropriate request method"""
         
         if not FHIR_AVAILABLE:


### PR DESCRIPTION
## Summary
- avoid runtime NameError when the optional fhir.resources package is unavailable by guarding BundleEntry type hints
- provide a fallback alias for BundleEntry so the bundle assembler can still load and use fallback logic

## Testing
- `pytest` *(fails: missing optional dependencies such as requests, fastapi, pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68ccfba38ae8832aa18ab0ec7124e0d6