### PR TITLE
Improve comment clarity across summarization pipeline

### DIFF
--- a/src/nl_fhir/main.py
+++ b/src/nl_fhir/main.py
@@ -87,7 +87,7 @@ app.add_middleware(
     allow_headers=["content-type"],  # Restrict headers
 )
 
-# Add custom middleware
+# Register custom middleware in order so validation runs before headers are added
 app.middleware("http")(request_timing_and_validation)
 app.middleware("http")(add_security_headers)
 

--- a/src/nl_fhir/services/summarization/fhir_bundle_summarizer.py
+++ b/src/nl_fhir/services/summarization/fhir_bundle_summarizer.py
@@ -33,7 +33,7 @@ class FHIRBundleSummarizer:
         self.bundle_analyzer = BundleAnalyzer()
         self.monitoring = ProductionMonitoringMixin()
         
-        # Lazy-loaded tier processors (will be implemented in subsequent stories)
+        # Lazy-load tier processors so new engines can be attached without increasing startup cost
         self._generic_engine = None
         self._llm_service = None
     
@@ -78,7 +78,7 @@ class FHIRBundleSummarizer:
                 processing_time_ms=processing_time,
                 total_time_ms=total_time,
                 output_quality_score=summary.confidence_score,
-                server_instance="fhir-summarizer-1",  # TODO: get from config
+                server_instance="fhir-summarizer-1",  # Use explicit identifier until deployment metadata is exposed via configuration
                 api_version="4.1.0",
                 user_role=role,
                 specialty_context=analysis.specialty_context

--- a/src/nl_fhir/services/summarization/resource_summarizer_registry.py
+++ b/src/nl_fhir/services/summarization/resource_summarizer_registry.py
@@ -44,7 +44,7 @@ class BaseResourceSummarizer(ABC):
             if coding.get('display'):
                 return coding['display']
             elif coding.get('code'):
-                # Simple fallback - in production would use terminology mapping
+                # Provide readable fallback when terminology services are not yet integrated
                 return coding['code'].replace('_', ' ').title()
         return "Unknown"
     


### PR DESCRIPTION
## Summary
- clarify middleware registration order in the FastAPI application entrypoint
- document lazy-loading rationale and configuration placeholder within the summarization orchestrator
- update terminology fallback comment to explain behavior when terminology services are unavailable

## Testing
- pytest -q *(fails: missing optional test dependencies such as requests, fastapi, pydantic, nl_fhir)*

------
https://chatgpt.com/codex/tasks/task_e_68cea3fae118832a88aba809152dea02