### PR TITLE
Harden FastAPI backend security

### DIFF
--- a/src/nl_fhir/api/middleware/__init__.py
+++ b/src/nl_fhir/api/middleware/__init__.py
@@ -7,9 +7,11 @@ Medical Safety: Input validation required
 from .timing import request_timing_and_validation
 from .security import add_security_headers
 from .sanitization import sanitize_clinical_text
+from .rate_limit import rate_limit_middleware
 
 __all__ = [
     "request_timing_and_validation",
     "add_security_headers",
     "sanitize_clinical_text",
+    "rate_limit_middleware",
 ]

--- a/src/nl_fhir/api/middleware/rate_limit.py
+++ b/src/nl_fhir/api/middleware/rate_limit.py
@@ -1,0 +1,69 @@
+"""Simple in-process rate limiting middleware."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from time import monotonic
+from typing import Deque, Dict
+
+from fastapi import Request, status
+from fastapi.responses import JSONResponse
+
+from ...config import settings
+
+
+class _RateLimitState:
+    """Track request timestamps for a given client key."""
+
+    def __init__(self, max_requests: int, window_seconds: int) -> None:
+        self.max_requests = max_requests
+        self.window_seconds = float(window_seconds)
+        self._requests: Dict[str, Deque[float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def register(self, key: str) -> tuple[bool, float | None]:
+        """Register a request and determine if it exceeds the quota."""
+
+        async with self._lock:
+            now = monotonic()
+            window_start = now - self.window_seconds
+            entries = self._requests.setdefault(key, deque())
+
+            while entries and entries[0] < window_start:
+                entries.popleft()
+
+            if len(entries) >= self.max_requests:
+                retry_after = max(entries[0] + self.window_seconds - now, 0.0)
+                return False, retry_after
+
+            entries.append(now)
+            return True, None
+
+
+_rate_limit_state = _RateLimitState(
+    settings.rate_limit_requests_per_minute,
+    settings.rate_limit_window_seconds,
+)
+
+
+async def rate_limit_middleware(request: Request, call_next):
+    """Reject requests that exceed the configured rate limit."""
+
+    client_ip = request.headers.get("x-forwarded-for", "").split(",")[0].strip()
+    if not client_ip:
+        client_ip = request.client.host if request.client else "anonymous"
+
+    allowed, retry_after = await _rate_limit_state.register(client_ip)
+    if not allowed:
+        headers = {"Retry-After": f"{int(retry_after or 0)}"}
+        return JSONResponse(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            content={
+                "error": "Too many requests. Please retry later.",
+                "client": client_ip,
+            },
+            headers=headers,
+        )
+
+    return await call_next(request)

--- a/src/nl_fhir/api/middleware/security.py
+++ b/src/nl_fhir/api/middleware/security.py
@@ -1,20 +1,46 @@
-"""
-NL-FHIR Security Headers Middleware
-HIPAA Compliant: No PHI logging
-Medical Safety: Input validation required
-"""
+"""NL-FHIR security header middleware."""
+
+from __future__ import annotations
+
+from typing import Final
 
 from fastapi import Request
 
+from ...config import settings
+
+_CSP_POLICY: Final[str] = (
+    "default-src 'self'; "
+    "script-src 'self'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data:; "
+    "font-src 'self' data:; "
+    "connect-src 'self'; "
+    "frame-ancestors 'none'; "
+    "form-action 'self'; "
+    "base-uri 'self'"
+)
+
 
 async def add_security_headers(request: Request, call_next):
-    """Add security headers to all responses"""
+    """Add hardened security headers to all responses."""
+
     response = await call_next(request)
+
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["X-XSS-Protection"] = "1; mode=block"
-    response.headers["Strict-Transport-Security"] = (
-        "max-age=31536000; includeSubDomains"
-    )
     response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    response.headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()"
+    response.headers["Content-Security-Policy"] = _CSP_POLICY
+
+    if settings.is_production:
+        scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
+        if scheme == "https":
+            response.headers["Strict-Transport-Security"] = (
+                "max-age=63072000; includeSubDomains; preload"
+            )
+    else:
+        response.headers.pop("Strict-Transport-Security", None)
+
     return response

--- a/src/nl_fhir/api/middleware/timing.py
+++ b/src/nl_fhir/api/middleware/timing.py
@@ -11,11 +11,13 @@ from uuid import uuid4
 from fastapi import Request, status
 from fastapi.responses import JSONResponse
 
+from ...config import settings
+
 logger = logging.getLogger(__name__)
 
-# Security and performance metrics
-REQUEST_TIMEOUT_SECONDS = 30.0
-MAX_REQUEST_SIZE_BYTES = 1024 * 1024  # 1MB
+# Security and performance metrics (configurable via settings)
+REQUEST_TIMEOUT_SECONDS = settings.request_timeout_seconds
+MAX_REQUEST_SIZE_BYTES = settings.max_request_size_bytes
 
 
 async def request_timing_and_validation(request: Request, call_next):

--- a/src/nl_fhir/config.py
+++ b/src/nl_fhir/config.py
@@ -41,7 +41,13 @@ class Settings(BaseSettings):
         env="ALLOWED_HOSTS"
     )
     cors_origins: List[str] = Field(
-        default=["http://localhost:3000", "http://localhost:8080"],
+        default=[
+            "http://localhost:3000",
+            "http://localhost:8080",
+            "http://localhost:8000",
+            "http://127.0.0.1:8000",
+            "https://*.railway.app",
+        ],
         env="CORS_ORIGINS"
     )
     trusted_hosts: List[str] = Field(
@@ -53,6 +59,7 @@ class Settings(BaseSettings):
     max_request_size_mb: int = Field(default=1, env="MAX_REQUEST_SIZE_MB")
     request_timeout_seconds: float = Field(default=30.0, env="REQUEST_TIMEOUT_SECONDS")
     rate_limit_requests_per_minute: int = Field(default=100, env="RATE_LIMIT_REQUESTS_PER_MINUTE")
+    rate_limit_window_seconds: int = Field(default=60, env="RATE_LIMIT_WINDOW_SECONDS")
     workers: int = Field(default=4, env="WORKERS")
     
     # Logging Settings

--- a/src/nl_fhir/main.py
+++ b/src/nl_fhir/main.py
@@ -6,8 +6,8 @@ Medical Safety: Input validation required
 
 import logging
 import logging.config
-from typing import Optional
 import re
+from typing import List, Optional
 
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
@@ -31,6 +31,7 @@ from .api.middleware import (
     request_timing_and_validation,
     add_security_headers,
     sanitize_clinical_text,
+    rate_limit_middleware,
 )
 
 from .config import settings
@@ -47,12 +48,17 @@ except Exception:
 logger = logging.getLogger(__name__)
 
 # FastAPI application with enhanced metadata for Story 1.2
+docs_url = "/docs" if not settings.is_production else None
+redoc_url = "/redoc" if not settings.is_production else None
+openapi_url = "/openapi.json" if not settings.is_production else None
+
 app = FastAPI(
     title="NL-FHIR Converter",
     description="Natural Language to FHIR R4 Bundle Converter - Epic 1 Complete",
     version="1.0.0",
-    docs_url="/docs",  # OpenAPI documentation
-    redoc_url="/redoc",  # Alternative documentation
+    docs_url=docs_url,
+    redoc_url=redoc_url,
+    openapi_url=openapi_url,
     contact={
         "name": "NL-FHIR Development Team",
         "email": "dev@nl-fhir.example.com",
@@ -66,28 +72,38 @@ app = FastAPI(
 # Security middleware - trusted host protection
 app.add_middleware(
     TrustedHostMiddleware,
-    allowed_hosts=[
-        "localhost",
-        "127.0.0.1",
-        "*.railway.app",
-        "testserver",
-    ],  # testserver for tests
+    allowed_hosts=settings.trusted_hosts,
 )
 
 # CORS configuration - restricted for production security
+def _split_cors_origins(origins: List[str]) -> tuple[List[str], Optional[str]]:
+    explicit: List[str] = []
+    regex_patterns: List[str] = []
+
+    for origin in origins:
+        if "*" in origin:
+            pattern = "^" + re.escape(origin).replace("\\*", ".*") + "$"
+            regex_patterns.append(pattern)
+        else:
+            explicit.append(origin)
+
+    regex = "|".join(regex_patterns) if regex_patterns else None
+    return explicit, regex
+
+
+cors_origins, cors_regex = _split_cors_origins(settings.cors_origins)
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:8000",
-        "http://127.0.0.1:8000",
-        "https://*.railway.app",  # Production deployment
-    ],
+    allow_origins=cors_origins,
+    allow_origin_regex=cors_regex,
     allow_credentials=False,  # Security: disable credentials
     allow_methods=["GET", "POST"],  # Restrict to required methods
     allow_headers=["content-type"],  # Restrict headers
 )
 
 # Register custom middleware in order so validation runs before headers are added
+app.middleware("http")(rate_limit_middleware)
 app.middleware("http")(request_timing_and_validation)
 app.middleware("http")(add_security_headers)
 


### PR DESCRIPTION
## Summary
- gate interactive API documentation behind non-production environments and centralize host/CORS configuration with wildcard-aware handling
- introduce configurable in-process rate limiting middleware to block abusive clients and expose tuning knobs in the settings
- harden response security headers with CSP, referrer, and permissions policies while respecting HTTPS-only HSTS and reading request guardrails from settings

## Testing
- pytest *(fails: missing optional test dependencies such as fastapi/requests/pydantic in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d04eb6b9f0832aa9137d3ee8406c98