### PR TITLE
safety: split shared data to honor file size cap

### DIFF
--- a/src/nl_fhir/services/safety/__init__.py
+++ b/src/nl_fhir/services/safety/__init__.py
@@ -8,7 +8,8 @@ from .interaction_checker import DrugInteractionChecker, InteractionSeverity, Dr
 from .contraindication_checker import ContraindicationChecker, ContraindicationSeverity, Contraindication
 from .dosage_validator import DosageValidator, DosageViolationSeverity, DosageViolation
 from .clinical_decision_support import ClinicalDecisionSupport, RecommendationType, ClinicalRecommendation
-from .risk_scorer import SafetyRiskScorer, RiskLevel, SafetyAlert, SafetyRiskScore
+from .risk_scorer import SafetyRiskScorer
+from .risk_models import RiskLevel, SafetyAlert, SafetyRiskScore
 from .enhanced_safety_validator import EnhancedSafetyValidator
 
 __all__ = [

--- a/src/nl_fhir/services/safety/contraindication_data.py
+++ b/src/nl_fhir/services/safety/contraindication_data.py
@@ -1,0 +1,177 @@
+"""
+Shared contraindication datasets used by ContraindicationChecker.
+
+Separating the data structures keeps the checker module within the
+constitutional 500-line limit while centralizing reference data for reuse.
+"""
+
+from typing import Dict, Any
+
+CONTRAINDICATIONS: Dict[str, Dict[str, Any]] = {
+    # Cardiovascular contraindications
+    "metoprolol+asthma": {
+        "severity": "absolute",
+        "reason": "Beta-blockers can cause severe bronchospasm in asthma",
+        "alternatives": ["Calcium channel blockers", "ACE inhibitors"],
+        "monitoring": ["Respiratory function"],
+        "evidence_level": "high",
+    },
+    "propranolol+asthma": {
+        "severity": "absolute",
+        "reason": "Non-selective beta-blocker contraindicated in asthma",
+        "alternatives": [
+            "Cardioselective beta-blockers if essential",
+            "Alternative antihypertensives",
+        ],
+        "monitoring": ["Respiratory function"],
+        "evidence_level": "high",
+    },
+    "diltiazem+heart failure": {
+        "severity": "relative",
+        "reason": "Negative inotropic effect may worsen heart failure",
+        "alternatives": ["ACE inhibitors", "ARBs", "Beta-blockers"],
+        "monitoring": ["Left ventricular function", "Symptoms"],
+        "evidence_level": "high",
+    },
+    # Kidney disease contraindications
+    "metformin+kidney disease": {
+        "severity": "absolute",
+        "reason": "Risk of lactic acidosis with reduced kidney function",
+        "alternatives": ["Insulin", "Sulfonylureas", "DPP-4 inhibitors"],
+        "monitoring": ["Kidney function"],
+        "evidence_level": "high",
+    },
+    "nsaid+kidney disease": {
+        "severity": "relative",
+        "reason": "Further reduction in kidney function",
+        "alternatives": ["Acetaminophen", "Topical analgesics"],
+        "monitoring": ["Serum creatinine", "BUN"],
+        "evidence_level": "high",
+    },
+    # Liver disease contraindications
+    "acetaminophen+liver disease": {
+        "severity": "relative",
+        "reason": "Hepatotoxicity risk with compromised liver function",
+        "alternatives": ["Low-dose options", "Alternative analgesics"],
+        "monitoring": ["Liver function tests"],
+        "evidence_level": "high",
+    },
+    "simvastatin+liver disease": {
+        "severity": "absolute",
+        "reason": "Risk of hepatotoxicity",
+        "alternatives": ["Lifestyle modifications", "Alternative lipid management"],
+        "monitoring": ["Liver function tests"],
+        "evidence_level": "high",
+    },
+    # GI contraindications
+    "nsaid+peptic ulcer": {
+        "severity": "relative",
+        "reason": "Risk of GI bleeding and ulcer perforation",
+        "alternatives": ["Acetaminophen", "COX-2 selective NSAIDs with PPI"],
+        "monitoring": ["GI symptoms", "Hemoglobin"],
+        "evidence_level": "high",
+    },
+    "aspirin+peptic ulcer": {
+        "severity": "relative",
+        "reason": "Increased bleeding risk",
+        "alternatives": ["Clopidogrel", "Aspirin with PPI"],
+        "monitoring": ["GI symptoms", "Complete blood count"],
+        "evidence_level": "high",
+    },
+    # Psychiatric contraindications
+    "fluoxetine+bipolar disorder": {
+        "severity": "caution",
+        "reason": "Risk of triggering manic episodes",
+        "alternatives": ["Mood stabilizers first", "Atypical antipsychotics"],
+        "monitoring": ["Mood symptoms", "Manic episodes"],
+        "evidence_level": "moderate",
+    },
+}
+
+AGE_CONTRAINDICATIONS: Dict[str, Dict[str, Any]] = {
+    # Pediatric contraindications
+    "aspirin+pediatric": {
+        "severity": "absolute",
+        "reason": "Risk of Reye's syndrome in children",
+        "alternatives": ["Acetaminophen", "Ibuprofen (>6 months)"],
+        "monitoring": ["Fever", "Neurological symptoms"],
+        "evidence_level": "high",
+    },
+    "tetracycline+pediatric": {
+        "severity": "absolute",
+        "reason": "Tooth discoloration and growth inhibition",
+        "alternatives": ["Penicillins", "Macrolides", "Cephalosporins"],
+        "monitoring": ["Dental development"],
+        "evidence_level": "high",
+    },
+    "fluoroquinolone+pediatric": {
+        "severity": "relative",
+        "reason": "Cartilage damage risk",
+        "alternatives": ["Beta-lactam antibiotics", "Macrolides"],
+        "monitoring": ["Joint symptoms"],
+        "evidence_level": "high",
+    },
+    # Geriatric considerations
+    "diphenhydramine+geriatric": {
+        "severity": "caution",
+        "reason": "Anticholinergic effects, falls risk",
+        "alternatives": ["Loratadine", "Cetirizine"],
+        "monitoring": ["Cognitive function", "Falls assessment"],
+        "evidence_level": "high",
+    },
+    "benzodiazepine+geriatric": {
+        "severity": "caution",
+        "reason": "Increased sedation, falls, cognitive impairment",
+        "alternatives": ["Non-benzodiazepine sleep aids", "CBT"],
+        "monitoring": ["Cognitive function", "Falls risk"],
+        "evidence_level": "high",
+    },
+    "nsaid+geriatric": {
+        "severity": "caution",
+        "reason": "Increased GI bleeding and cardiovascular risk",
+        "alternatives": ["Acetaminophen", "Topical preparations"],
+        "monitoring": ["GI symptoms", "Kidney function", "Blood pressure"],
+        "evidence_level": "high",
+    },
+}
+
+PREGNANCY_CONTRAINDICATIONS: Dict[str, Dict[str, Any]] = {
+    "warfarin": {
+        "category": "X",
+        "reason": "Teratogenic effects, fetal bleeding",
+        "alternatives": ["Heparin", "Low molecular weight heparin"],
+        "monitoring": ["Coagulation studies"],
+    },
+    "isotretinoin": {
+        "category": "X",
+        "reason": "Severe birth defects",
+        "alternatives": ["Topical retinoids", "Alternative acne treatments"],
+        "monitoring": ["Pregnancy testing"],
+    },
+    "lisinopril": {
+        "category": "D",
+        "reason": "Fetal kidney damage, oligohydramnios",
+        "alternatives": ["Methyldopa", "Labetalol", "Nifedipine"],
+        "monitoring": ["Fetal growth", "Amniotic fluid"],
+    },
+    "atenolol": {
+        "category": "D",
+        "reason": "Fetal growth restriction",
+        "alternatives": ["Methyldopa", "Labetalol"],
+        "monitoring": ["Fetal growth", "Heart rate"],
+    },
+    "phenytoin": {
+        "category": "D",
+        "reason": "Fetal hydantoin syndrome",
+        "alternatives": ["Lamotrigine", "Levetiracetam"],
+        "monitoring": ["Fetal development", "Drug levels"],
+    },
+}
+
+ALLERGY_CROSS_REACTIONS: Dict[str, Any] = {
+    "penicillin": ["amoxicillin", "ampicillin", "cephalexin", "cefazolin"],
+    "sulfa": ["sulfamethoxazole", "furosemide", "hydrochlorothiazide"],
+    "aspirin": ["ibuprofen", "naproxen", "diclofenac", "celecoxib"],
+    "codeine": ["morphine", "oxycodone", "hydrocodone"],
+    "latex": ["avocado", "banana", "kiwi", "chestnut"],
+}

--- a/src/nl_fhir/services/safety/dosage_data.py
+++ b/src/nl_fhir/services/safety/dosage_data.py
@@ -1,0 +1,210 @@
+"""
+Shared dosage reference data for DosageValidator.
+
+Extracting the static datasets keeps the validator implementation
+within the 500-line constitutional ceiling and makes it easier to
+maintain dosage ranges and adjustment factors independently.
+"""
+
+from typing import Dict, List, Any, Tuple
+
+DOSAGE_DATABASE: Dict[str, List[Dict[str, Any]]] = {
+    "acetaminophen": [
+        {
+            "min_dose": 325,
+            "max_dose": 4000,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "adult",
+        },
+        {
+            "min_dose": 10,
+            "max_dose": 15,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "child",
+            "weight_based": True,
+        },
+        {
+            "min_dose": 160,
+            "max_dose": 3200,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "geriatric",
+        },
+    ],
+    "ibuprofen": [
+        {
+            "min_dose": 400,
+            "max_dose": 2400,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "adult",
+        },
+        {
+            "min_dose": 5,
+            "max_dose": 10,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "child",
+            "weight_based": True,
+        },
+        {
+            "min_dose": 400,
+            "max_dose": 1600,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "geriatric",
+        },
+    ],
+    "simvastatin": [
+        {
+            "min_dose": 10,
+            "max_dose": 80,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "adult",
+        },
+        {
+            "min_dose": 10,
+            "max_dose": 40,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "geriatric",
+        },
+    ],
+    "lisinopril": [
+        {
+            "min_dose": 2.5,
+            "max_dose": 40,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "adult",
+        },
+        {
+            "min_dose": 2.5,
+            "max_dose": 20,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "geriatric",
+        },
+    ],
+    "metformin": [
+        {
+            "min_dose": 500,
+            "max_dose": 2550,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "adult",
+        },
+        {
+            "min_dose": 500,
+            "max_dose": 2000,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "geriatric",
+        },
+    ],
+    "warfarin": [
+        {
+            "min_dose": 1,
+            "max_dose": 15,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "adult",
+        },
+        {
+            "min_dose": 1,
+            "max_dose": 10,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "geriatric",
+        },
+    ],
+    "digoxin": [
+        {
+            "min_dose": 0.125,
+            "max_dose": 0.5,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "adult",
+        },
+        {
+            "min_dose": 0.0625,
+            "max_dose": 0.25,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "geriatric",
+        },
+    ],
+    "amlodipine": [
+        {
+            "min_dose": 2.5,
+            "max_dose": 10,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "adult",
+        },
+        {
+            "min_dose": 2.5,
+            "max_dose": 5,
+            "unit": "mg",
+            "frequency": "daily",
+            "route": "oral",
+            "age_group": "geriatric",
+        },
+    ],
+}
+
+AGE_WEIGHT_FACTORS: Dict[str, Dict[str, float]] = {
+    "infant": {"dose_factor": 0.1, "weight_factor": 1.0},
+    "child": {"dose_factor": 0.5, "weight_factor": 1.0},
+    "adolescent": {"dose_factor": 0.8, "weight_factor": 1.0},
+    "adult": {"dose_factor": 1.0, "weight_factor": 1.0},
+    "geriatric": {"dose_factor": 0.75, "weight_factor": 1.0},
+}
+
+ROUTE_CONVERSIONS: Dict[Tuple[str, str], float] = {
+    ("oral", "iv"): 0.5,   # IV typically 50% of oral dose
+    ("iv", "oral"): 2.0,   # Oral typically 200% of IV dose
+    ("im", "oral"): 1.5,   # IM typically 150% of oral dose
+    ("oral", "im"): 0.67,  # Oral to IM conversion
+}
+
+UNIT_CONVERSIONS: Dict[Tuple[str, str], float] = {
+    ("mg", "g"): 0.001,
+    ("g", "mg"): 1000,
+    ("mcg", "mg"): 0.001,
+    ("mg", "mcg"): 1000,
+    ("mcg", "g"): 0.000001,
+    ("g", "mcg"): 1_000_000,
+}
+
+MONITORING_REQUIREMENTS: Dict[str, List[str]] = {
+    "acetaminophen": ["Liver function tests", "Daily maximum dose tracking"],
+    "ibuprofen": ["Kidney function", "GI symptoms"],
+    "simvastatin": ["Liver function tests", "Muscle symptoms"],
+    "lisinopril": ["Blood pressure", "Kidney function", "Potassium levels"],
+    "metformin": ["Kidney function", "Blood glucose"],
+    "warfarin": ["INR", "Bleeding signs"],
+    "digoxin": ["Heart rate", "Digoxin levels", "Electrolytes"],
+}
+
+DEFAULT_MONITORING: List[str] = ["Vital signs", "Symptom monitoring"]

--- a/src/nl_fhir/services/safety/dosage_models.py
+++ b/src/nl_fhir/services/safety/dosage_models.py
@@ -1,0 +1,66 @@
+"""
+Shared dosage domain models used across dosage safety components.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class DosageViolationSeverity(Enum):
+    """Dosage violation severity levels"""
+
+    CRITICAL = "critical"  # Potentially life-threatening
+    HIGH = "high"  # Serious adverse effects likely
+    MODERATE = "moderate"  # Monitoring required
+    LOW = "low"  # Minor concern
+
+
+@dataclass
+class DosageRange:
+    """Safe dosage range model"""
+
+    min_dose: float
+    max_dose: float
+    unit: str
+    frequency: str
+    route: str
+    age_group: Optional[str] = None
+    weight_based: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "min_dose": self.min_dose,
+            "max_dose": self.max_dose,
+            "unit": self.unit,
+            "frequency": self.frequency,
+            "route": self.route,
+            "age_group": self.age_group,
+            "weight_based": self.weight_based,
+        }
+
+
+@dataclass
+class DosageViolation:
+    """Dosage safety violation model"""
+
+    medication: str
+    prescribed_dose: str
+    safe_range: DosageRange
+    violation_type: str
+    severity: DosageViolationSeverity
+    reason: str
+    recommendation: str
+    monitoring_requirements: List[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "medication": self.medication,
+            "prescribed_dose": self.prescribed_dose,
+            "safe_range": self.safe_range.to_dict(),
+            "violation_type": self.violation_type,
+            "severity": self.severity.value,
+            "reason": self.reason,
+            "recommendation": self.recommendation,
+            "monitoring_requirements": self.monitoring_requirements,
+        }

--- a/src/nl_fhir/services/safety/dosage_normalization.py
+++ b/src/nl_fhir/services/safety/dosage_normalization.py
@@ -1,0 +1,30 @@
+"""
+Normalization helpers for dosage safety processing.
+"""
+
+import re
+
+
+def normalize_medication_name(name: str) -> str:
+    """Normalize medication name for dosage checking."""
+    if not name:
+        return ""
+
+    normalized = name.lower().strip()
+    # Remove dosage information to get base drug name
+    normalized = re.sub(r"\d+\s*(mg|mcg|g|ml|units?)\b", "", normalized)
+    normalized = re.sub(r"\b(tablet|capsule|injection|solution)s?\b", "", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+
+    brand_to_generic = {
+        "tylenol": "acetaminophen",
+        "advil": "ibuprofen",
+        "motrin": "ibuprofen",
+        "zocor": "simvastatin",
+        "lipitor": "atorvastatin",
+        "prinivil": "lisinopril",
+        "zestril": "lisinopril",
+        "norvasc": "amlodipine",
+    }
+
+    return brand_to_generic.get(normalized, normalized)

--- a/src/nl_fhir/services/safety/risk_alerts.py
+++ b/src/nl_fhir/services/safety/risk_alerts.py
@@ -1,0 +1,173 @@
+"""
+Alert generation helpers for safety risk scoring.
+"""
+
+from typing import Any, Dict, List
+
+from .risk_models import SafetyRiskScore, SafetyAlert, AlertSeverity, RiskLevel
+
+
+def build_safety_alerts(
+    risk_score: SafetyRiskScore,
+    interaction_results: Dict[str, Any],
+    contraindication_results: Dict[str, Any],
+    dosage_results: Dict[str, Any],
+) -> List[SafetyAlert]:
+    """Generate prioritized safety alerts based on risk assessment."""
+
+    alerts: List[SafetyAlert] = []
+    alert_counter = 1
+
+    if interaction_results.get("has_interactions"):
+        contraindicated = [
+            i
+            for i in interaction_results.get("interactions", [])
+            if i.get("severity") == "contraindicated"
+        ]
+        major = [
+            i
+            for i in interaction_results.get("interactions", [])
+            if i.get("severity") == "major"
+        ]
+
+        if contraindicated:
+            alerts.append(
+                SafetyAlert(
+                    alert_id=f"ALERT-{alert_counter:03d}",
+                    severity=AlertSeverity.URGENT,
+                    category="Drug Interactions",
+                    title="Contraindicated Drug Combination Detected",
+                    description=(
+                        f"Found {len(contraindicated)} contraindicated drug interaction(s) "
+                        "requiring immediate attention"
+                    ),
+                    affected_medications=[i["drug_a"] for i in contraindicated]
+                    + [i["drug_b"] for i in contraindicated],
+                    required_actions=[
+                        "Stop contraindicated medications immediately",
+                        "Consult prescriber for alternative therapy",
+                        "Monitor patient for adverse effects",
+                    ],
+                    timeline="Immediate (within 1 hour)",
+                    escalation_criteria=[
+                        "Patient shows signs of adverse reaction",
+                        "Unable to contact prescriber within 2 hours",
+                    ],
+                )
+            )
+            alert_counter += 1
+
+        if major:
+            alerts.append(
+                SafetyAlert(
+                    alert_id=f"ALERT-{alert_counter:03d}",
+                    severity=AlertSeverity.ALERT,
+                    category="Drug Interactions",
+                    title="Major Drug Interactions Require Monitoring",
+                    description=(
+                        f"Found {len(major)} major drug interaction(s) requiring close monitoring"
+                    ),
+                    affected_medications=[i["drug_a"] for i in major]
+                    + [i["drug_b"] for i in major],
+                    required_actions=[
+                        "Implement enhanced monitoring protocols",
+                        "Consider dose adjustments",
+                        "Educate patient about signs/symptoms to watch",
+                    ],
+                    timeline="Within 24 hours",
+                    escalation_criteria=[
+                        "Patient develops symptoms",
+                        "Lab values show adverse trends",
+                    ],
+                )
+            )
+            alert_counter += 1
+
+    if contraindication_results.get("has_contraindications"):
+        absolute = [
+            c
+            for c in contraindication_results.get("contraindications", [])
+            if c.get("severity") == "absolute"
+        ]
+
+        if absolute:
+            alerts.append(
+                SafetyAlert(
+                    alert_id=f"ALERT-{alert_counter:03d}",
+                    severity=AlertSeverity.URGENT,
+                    category="Contraindications",
+                    title="Absolute Contraindications Detected",
+                    description=(
+                        f"Found {len(absolute)} absolute contraindication(s) requiring "
+                        "medication discontinuation"
+                    ),
+                    affected_medications=[c["medication"] for c in absolute],
+                    required_actions=[
+                        "Discontinue contraindicated medications",
+                        "Assess for alternative therapies",
+                        "Monitor for withdrawal effects if applicable",
+                    ],
+                    timeline="Immediate (within 1 hour)",
+                    escalation_criteria=[
+                        "Patient at immediate risk",
+                        "No safe alternatives available",
+                    ],
+                )
+            )
+            alert_counter += 1
+
+    if dosage_results.get("has_dosage_violations"):
+        critical = [
+            v
+            for v in dosage_results.get("violations", [])
+            if v.get("severity") == "critical"
+        ]
+
+        if critical:
+            alerts.append(
+                SafetyAlert(
+                    alert_id=f"ALERT-{alert_counter:03d}",
+                    severity=AlertSeverity.URGENT,
+                    category="Dosage Safety",
+                    title="Critical Dosage Violations Detected",
+                    description=(
+                        f"Found {len(critical)} critical dosage violation(s) with potential for serious harm"
+                    ),
+                    affected_medications=[v["medication"] for v in critical],
+                    required_actions=[
+                        "Verify and correct dosing immediately",
+                        "Assess patient for signs of overdose/underdose",
+                        "Consider antidote if overdose suspected",
+                    ],
+                    timeline="Immediate (within 30 minutes)",
+                    escalation_criteria=[
+                        "Signs of toxicity present",
+                        "Dosing error confirmed",
+                    ],
+                )
+            )
+            alert_counter += 1
+
+    if risk_score.risk_level in [RiskLevel.HIGH, RiskLevel.CRITICAL]:
+        alerts.append(
+            SafetyAlert(
+                alert_id=f"ALERT-{alert_counter:03d}",
+                severity=AlertSeverity.ALERT
+                if risk_score.risk_level == RiskLevel.HIGH
+                else AlertSeverity.URGENT,
+                category="Overall Risk",
+                title=f"{risk_score.risk_level.value.title()} Safety Risk Profile",
+                description=(
+                    f"Patient has {risk_score.risk_level.value} overall safety risk "
+                    f"(score: {risk_score.overall_score:.1f}/100)"
+                ),
+                affected_medications=[],
+                required_actions=risk_score.recommendations[:3],
+                timeline="Within 24 hours"
+                if risk_score.risk_level == RiskLevel.HIGH
+                else "Within 4 hours",
+                escalation_criteria=risk_score.escalation_triggers,
+            )
+        )
+
+    return alerts

--- a/src/nl_fhir/services/safety/risk_data.py
+++ b/src/nl_fhir/services/safety/risk_data.py
@@ -1,0 +1,21 @@
+"""
+Shared reference data for safety risk scoring.
+"""
+
+from typing import Dict
+
+RISK_WEIGHTS: Dict[str, float] = {
+    "drug_interactions": 0.25,
+    "contraindications": 0.22,
+    "dosage_concerns": 0.20,
+    "patient_complexity": 0.15,
+    "monitoring_requirements": 0.10,
+    "medication_burden": 0.08,
+}
+
+HIGH_MONITORING_MEDICATIONS: Dict[str, str] = {
+    "warfarin": "INR monitoring every 1-2 weeks",
+    "digoxin": "Digoxin levels and electrolyte monitoring",
+    "lithium": "Lithium levels every 3-6 months",
+    "metformin": "Kidney function monitoring every 3-6 months",
+}

--- a/src/nl_fhir/services/safety/risk_models.py
+++ b/src/nl_fhir/services/safety/risk_models.py
@@ -1,0 +1,78 @@
+"""
+Shared models and enums for safety risk scoring.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List
+
+
+class RiskLevel(Enum):
+    """Overall risk level classification."""
+
+    MINIMAL = "minimal"  # 0-20: Routine care
+    LOW = "low"  # 21-40: Standard monitoring
+    MODERATE = "moderate"  # 41-60: Enhanced monitoring
+    HIGH = "high"  # 61-80: Close monitoring required
+    CRITICAL = "critical"  # 81-100: Immediate intervention
+
+
+class AlertSeverity(Enum):
+    """Safety alert severity levels."""
+
+    INFO = "info"  # Informational only
+    WARNING = "warning"  # Attention required
+    ALERT = "alert"  # Action recommended
+    URGENT = "urgent"  # Immediate action required
+
+
+@dataclass
+class SafetyAlert:
+    """Safety alert model."""
+
+    alert_id: str
+    severity: AlertSeverity
+    category: str
+    title: str
+    description: str
+    affected_medications: List[str]
+    required_actions: List[str]
+    timeline: str
+    escalation_criteria: List[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "alert_id": self.alert_id,
+            "severity": self.severity.value,
+            "category": self.category,
+            "title": self.title,
+            "description": self.description,
+            "affected_medications": self.affected_medications,
+            "required_actions": self.required_actions,
+            "timeline": self.timeline,
+            "escalation_criteria": self.escalation_criteria,
+        }
+
+
+@dataclass
+class SafetyRiskScore:
+    """Comprehensive safety risk score."""
+
+    overall_score: float
+    risk_level: RiskLevel
+    contributing_factors: Dict[str, float]
+    risk_components: Dict[str, Dict[str, Any]]
+    recommendations: List[str]
+    monitoring_requirements: List[str]
+    escalation_triggers: List[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "overall_score": self.overall_score,
+            "risk_level": self.risk_level.value,
+            "contributing_factors": self.contributing_factors,
+            "risk_components": self.risk_components,
+            "recommendations": self.recommendations,
+            "monitoring_requirements": self.monitoring_requirements,
+            "escalation_triggers": self.escalation_triggers,
+        }


### PR DESCRIPTION
## Summary
- move contraindication, dosage, and risk reference data into dedicated modules
- reuse shared models/normalizers so each safety service stays under the 500-line constitutional ceiling
- update safety package exports to match the new module layout

## Testing
- not run (no direct safety service tests available)
